### PR TITLE
Fixed the gender enumerator name to 'genders' as required in the seed.rb

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -19,7 +19,7 @@
 class Person < ActiveRecord::Base
   include PgSearch
 
-  enum gender: [:male, :female]
+  enum genders: [:male, :female]
 
   scope :sorted, ->{ order(first_name: :asc) }
   pg_search_scope :search,


### PR DESCRIPTION
When doing rake db:seed the Person.genders method is not found. I think that it is because the enumerator in the Person model is defined as 'gender' and not 'genders'. Change the enumerator's name to 'genders' the rake db:seed succeeds. 

Regards.
